### PR TITLE
Support a bit more than PHP

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -4,6 +4,24 @@ set fileformats=unix,dos
 set ruler
 set laststatus=2
 
+" Show line number.
+setlocal number
+
+" Support QuickFix for Ggrep.
+autocmd QuickFixCmdPost *grep* cwindow
+
+" Open tree navigation
+autocmd vimenter * NERDTree
+autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
+let g:NERDChristmasTree = 1
+let g:NERDTreeStatusline = 'Project explorer'
+
+" Toggle the tree explorer
+nnoremap <silent> <F7> :NERDTreeToggle<CR>
+
+" Focus to opened file window
+autocmd vimenter * wincmd w
+
 " Auto read when a file is changed from the outside.
 set autoread
 

--- a/ftplugin/php_basic.vim
+++ b/ftplugin/php_basic.vim
@@ -2,20 +2,12 @@
 setlocal makeprg=php\ -l\ %
 setlocal errorformat=%m\ in\ %f\ on\ line\ %l
 
-" Show line number.
-setlocal number
-
 " Show trailing whitespaces.
 highlight ExtraWhitespace ctermbg=red guibg=red
 match ExtraWhitespace /\s\+$/
 
 " Is ctags available?.
 let s:ctagsavailable = system('which ctags 2> /dev/null')
-
-"""""""""""" GIT & GREP """"""""""""""""""
-
-" Support QuickFix for Ggrep.
-autocmd QuickFixCmdPost *grep* cwindow
 
 """""""""""" PHPDOC """"""""""""""""""""""
 
@@ -79,20 +71,4 @@ if s:ctagsavailable =~ '/'
   nnoremap <silent> <F8> :TlistToggle<CR>
 
 endif
-
-"""""""""""" TREE NAVIGATION """""""""""""
-
-" Open tree navigation
-autocmd vimenter * NERDTree
-autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
-let g:NERDChristmasTree = 1
-let g:NERDTreeStatusline = 'Project explorer'
-
-" Toggle the tree explorer
-nnoremap <silent> <F7> :NERDTreeToggle<CR>
-
-"""""""""""" GENERAL """""""""""""""""""""
-
-" Focus to opened file window
-autocmd vimenter * wincmd w
 


### PR DESCRIPTION
I moved some line in .vimrc. It's not optimal but at least it will show why you should not have restricted vim to PHP files only :P 

I don't feel that anything should be limited to PHP. Everything works well with every files, why limiting all these great vim features to PHP? The first example that come to my mind: set numbers

Still TODO: you have to open a PHP file to be able to see the F8 right panel - which is a shame because this panel works very well with all type of file => js, html ... which are quite common in Moodle.
